### PR TITLE
Fixed syntax error in Unity 2018.3.5f1

### DIFF
--- a/PolygonMesh2D.cs
+++ b/PolygonMesh2D.cs
@@ -39,7 +39,7 @@ public class PolygonMesh2D : MonoBehaviour {
 		//recalculate UV
 		Bounds bounds = msh.bounds;
 
-		msh.uv = path.Select(v => new Vector2(v.x / bounds.size.x, v.y / bounds.size.y));
+		msh.uv = path.Select(v => new Vector2(v.x / bounds.size.x, v.y / bounds.size.y)).ToArray();
 	}
 
 	void Update() {


### PR DESCRIPTION
Mesh.uv is an array.

Super handy script by the way, I really like it for quick prototyping :)